### PR TITLE
Convert from seconds to duration

### DIFF
--- a/src/dbus_impl.rs
+++ b/src/dbus_impl.rs
@@ -1,5 +1,6 @@
 use crate::error::Error;
 use dbus;
+use std::time::Duration;
 
 // Based on https://bitbucket.org/pidgin/main/src/default/pidgin/gtkidle.c
 
@@ -9,7 +10,7 @@ const SCREENSAVERS: &'static [&'static [&'static str]] = &[
     &["org.kde.ScreenSaver", "/org/kde/ScreenSaver", "org.kde.ScreenSaver"]
 ];
 
-pub fn get_idle_time() -> Result<u64, Error> {
+pub fn get_idle_time() -> Result<Duration, Error> {
 
     for screensaver in SCREENSAVERS {
 
@@ -27,10 +28,11 @@ pub fn get_idle_time() -> Result<u64, Error> {
 
         // freedesktop seems to return the time in milliseconds??
         if screensaver[0] == "org.freedesktop.ScreenSaver" {
-            return Ok((time / 1000) as u64)
+            
+            return Ok(Duration::from_milis(time as u64))
         }
 
-        return Ok(time as u64)
+        return Ok(Duration::from_secs(time as u64))
 
     }
 

--- a/src/macos_impl.rs
+++ b/src/macos_impl.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use crate::error::Error;
 
 use IOKit_sys as io_kit;
@@ -7,7 +9,7 @@ use io_kit::IOMasterPort;
 use mach::{kern_return::KERN_SUCCESS, port::{MACH_PORT_NULL, mach_port_t}};
 use cf::{CFDataGetBytes, CFDataGetTypeID, CFDictionaryGetValueIfPresent, CFGetTypeID, CFNumberGetTypeID, CFNumberGetValue, CFRange, CFRelease, CFStringCreateWithCString, CFTypeRef, kCFAllocatorDefault, kCFNumberSInt64Type, kCFStringEncodingUTF8}; 
 
-pub fn get_idle_time() -> Result<u64, Error> {
+pub fn get_idle_time() -> Result<Duration, Error> {
     let mut ns = 0u64;
     let mut port: mach_port_t = 0;
     let mut iter = 0;
@@ -82,7 +84,7 @@ pub fn get_idle_time() -> Result<u64, Error> {
         io_kit::IOObjectRelease(iter);
     }
     let dur = std::time::Duration::from_nanos(ns);
-    Ok(dur.as_secs())
+    Ok(dur)
 }
 
 #[cfg(test)]

--- a/src/windows_impl.rs
+++ b/src/windows_impl.rs
@@ -7,10 +7,11 @@ use winapi::um::{
     },
     sysinfoapi::GetTickCount
 };
+use std::time::Duration;
 
 // Based on https://bitbucket.org/pidgin/main/src/8066acc5ed9306c5a53da8f66f50fb5cf38782c7/pidgin/win32/gtkwin32dep.c#lines-597
 
-pub fn get_idle_time() -> Result<u64, Error> {
+pub fn get_idle_time() -> Result<Duration, Error> {
 
     let now = unsafe { GetTickCount() };
 
@@ -24,7 +25,10 @@ pub fn get_idle_time() -> Result<u64, Error> {
     let ok = unsafe { GetLastInputInfo(p_last_input_info) } != 0;
 
     match ok {
-        true => Ok(((now - last_input_info.dwTime) / 1000) as u64),
+        true => {
+            let millis = now - last_input_info.dwTime;
+            Ok(Duration::from_millis(millis as u64))
+        },
         false => Err(Error::new("GetLastInputInfo failed"))
     }
 

--- a/src/x11_impl.rs
+++ b/src/x11_impl.rs
@@ -3,9 +3,10 @@ use x11::{
     xss::{XScreenSaverAllocInfo, XScreenSaverQueryInfo},
     xlib::{XOpenDisplay, XDefaultScreen, XRootWindow, XFree, XCloseDisplay}
 };
+use std::time::Duration;
 
 // Mostly taken from https://stackoverflow.com/questions/222606/detecting-keyboard-mouse-activity-in-linux
-pub fn get_idle_time() -> Result<u64, Error> {
+pub fn get_idle_time() -> Result<Duration, Error> {
 
     unsafe {
 
@@ -14,13 +15,13 @@ pub fn get_idle_time() -> Result<u64, Error> {
         let screen = XDefaultScreen(display);
         let root_window = XRootWindow(display, screen);
         let status = XScreenSaverQueryInfo(display, root_window, info);
-        let time = (*info).idle / 1000;
+        let time = (*info).idle;
 
         XFree(info as *mut std::ffi::c_void);
         XCloseDisplay(display);
 
         if status == 1 {
-            Ok(time)
+            Ok(Duration::from_millis(time))
         } else {
             Err(Error::new("Status not OK"))
         }


### PR DESCRIPTION
This adds the ability to preserve the idle time resolution provided by the OS by using a `Duration` as apposed to a `u64` which makes it a bit more flexible. The only negative to this change is that the value will be 16 bytes as apposed to 8 bytes. 

An alternative would be to continue to store this value as a `u64` but either use milliseconds or nanoseconds as the internal representation. 