### PR TITLE
Fix compilation issues on raspberry pi

### DIFF
--- a/src/x11_impl.rs
+++ b/src/x11_impl.rs
@@ -3,6 +3,7 @@ use x11::{
     xss::{XScreenSaverAllocInfo, XScreenSaverQueryInfo},
     xlib::{XOpenDisplay, XDefaultScreen, XRootWindow, XFree, XCloseDisplay}
 };
+use std::os::raw::c_char;
 use std::time::Duration;
 
 // Mostly taken from https://stackoverflow.com/questions/222606/detecting-keyboard-mouse-activity-in-linux
@@ -11,7 +12,7 @@ pub fn get_idle_time() -> Result<Duration, Error> {
     unsafe {
 
         let info = XScreenSaverAllocInfo();
-        let display = XOpenDisplay(0 as *const i8);
+        let display = XOpenDisplay(0 as *const c_char);
         let screen = XDefaultScreen(display);
         let root_window = XRootWindow(display, screen);
         let status = XScreenSaverQueryInfo(display, root_window, info);
@@ -21,7 +22,7 @@ pub fn get_idle_time() -> Result<Duration, Error> {
         XCloseDisplay(display);
 
         if status == 1 {
-            Ok(Duration::from_millis(time))
+            Ok(Duration::from_millis(time.into()))
         } else {
             Err(Error::new("Status not OK"))
         }


### PR DESCRIPTION
On RaspberryPi (and maybe on 32bit Linux installations as well) `c_char` compiles to `u8` and `c_ulong` compiles to `u32` instead of `i8` and `u64` respectively.
This uses the proper type for the display name and converts the time to `u64`.