### PR TITLE
Fix breaking misspelling in dbus_impl

### DIFF
--- a/src/dbus_impl.rs
+++ b/src/dbus_impl.rs
@@ -29,7 +29,7 @@ pub fn get_idle_time() -> Result<Duration, Error> {
         // freedesktop seems to return the time in milliseconds??
         if screensaver[0] == "org.freedesktop.ScreenSaver" {
             
-            return Ok(Duration::from_milis(time as u64))
+            return Ok(Duration::from_millis(time as u64))
         }
 
         return Ok(Duration::from_secs(time as u64))


### PR DESCRIPTION
dbus_impl had `Duration::from_milis`, which was causing an issue as `from_millis` has an additional `l`.