### PR TITLE
Correctly initalize `cbSize`

### DIFF
--- a/src/windows_impl.rs
+++ b/src/windows_impl.rs
@@ -16,7 +16,7 @@ pub fn get_idle_time() -> Result<Duration, Error> {
     let now = unsafe { GetTickCount() };
 
     let mut last_input_info = LASTINPUTINFO {
-        cbSize: 8, // ! Probably only true for 64 bit systems?
+        cbSize: std::mem::size_of::<LASTINPUTINFO>() as u32,
         dwTime: 0
     };
 


### PR DESCRIPTION
The struct `LASTINPUTINFO` has a hard coded value for cbSize which is supposed to represent the size of the struct. This is correct on 64 bit systems as noted but the correct way is to use size_of, something that bit me on a project I'm working on for some odd reasons.

adding this fix quickly here.